### PR TITLE
Post San Jose fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 aro-content/app/.DS_Store
 virtualenv/*
 site/*
+.npm

--- a/aro-content/100-setup/1-environment.md
+++ b/aro-content/100-setup/1-environment.md
@@ -2,7 +2,7 @@
 
 Your workshop environment consists of several components which have been pre-configured and are ready to use. This includes a [Microsoft Azure](https://azure.microsoft.com/en-us/){:target="_blank"} account, an [Azure Red Hat OpenShift](https://azure.microsoft.com/en-us/products/openshift/){:target="_blank"} cluster, and many other supporting resources.
 
-To access your working environment, you'll need to log into the Microsoft Azure portal by [clicking here](https://portal.azure.com){:target="_blank"}.  Use your provided username with `@rhcsbb.onmicrosoft.com`
+To access your working environment, you'll need to log into the [Microsoft Azure portal](https://portal.azure.com){:target="_blank"}.  Use your provided username with `@rhcsbb.onmicrosoft.com`. If you use the Azure portal regularly and it already knows a set of credentials for you, it's probably a good idea to use an Incognito window for this task, it should obviate the need to log out of an existing session.
 
 When prompted, you'll log in with the credentials provided by the workshop team.
 
@@ -49,7 +49,7 @@ Azure Cloud Shell is an interactive, authenticated, browser-accessible shell for
     | Storage account       | **user#mobbws** (Select *Use Existing* Button) | **user2mobbws** |
     | File share       | **acs** (Select *Use Existing* Button) | **acs** |
 
-1. Once completed, click on the *Create Storage* button to start your Azure Cloud Shell session.
+1. Once completed, click on the *Attach Storage* button to start your Azure Cloud Shell session.
 
     ![Cloud Shell Create Storage](../assets/images/cloud-shell-create-storage.png){ align=center }
 

--- a/aro-content/300-app/resilience.md
+++ b/aro-content/300-app/resilience.md
@@ -62,7 +62,7 @@ Then check that it has scaled
 
 A Pod disruption Budget (PBD) allows you to limit the disruption to your application when its pods need to be rescheduled for upgrades or routine maintenance work on ARO nodes. In essence, it lets developers define the minimum tolerable operational requirements for a deployment so that it remains stable even during a disruption.
 
-For example, frontend-js deployed as part of the last step contains three replicas distributed evenly across three nodes. We can tolerate losing two pods but not one, so we create a PDB that requires a minimum of one replica.
+For example, frontend-js deployed as part of the last step contains three replicas distributed evenly across three nodes. We can tolerate losing two pods but not three, so we create a PDB that requires a minimum of one replica.
 
 A PodDisruptionBudget object’s configuration consists of the following key parts:
 

--- a/aro-content/600-acs/1-cluster-install.md
+++ b/aro-content/600-acs/1-cluster-install.md
@@ -1,7 +1,9 @@
 ## Cluster ACS Registration
 
-Red Hat Advanced Cluster Security (RHACS) is a centralized service that provides bladdy bladdy
+Red Hat Advanced Cluster Security for Kubernetes (Red Hat Advanced Cluster Security or RHACS) provides the tools and capabilities to address the security needs of a cloud-native development approach on Kubernetes.
 
+The RHACS solution offers visibility into the security of your cluster, vulnerability management, and security compliance through auditing, network segmentation awareness and configuration, security risk profiling, security-related configuration management, threat detection, and incident response. In addition, RHACS grants an ability to pull the actions from that tooling deep into the application code development process through APIs.
+These security features represent the primary work any developer or administrator faces as they work across a range of environments, including multiple datacenters, private clouds, or public clouds that run Kubernetes clusters.
 
 ## Pre-requisites
 
@@ -25,7 +27,7 @@ The RHACS Central instance is configured to use SSO, so the Azure credentials th
 1. Log into the ACS Central Instance
 
     ```
-    https://central-rhacs-operator.apps.poc-adobe-acs.tsir.p1.openshiftapps.com:443
+    https://central-rhacs-operator.apps.poc-adobe-acs.5fge.p1.openshiftapps.com
     ```
 
 The admin interface looks like this: ![ACS-Console](acs-cluster-home.png)
@@ -36,10 +38,10 @@ The admin interface looks like this: ![ACS-Console](acs-cluster-home.png)
 
 1. On this screen, there's a button on the top right that says '+ New Cluster' which opens a dialog that we'll follow.
 
-1. There are only three **required** values to configure in this dialog: The 'Cluster Name', 'Central API Endpoint' (which must include a port number), and 'Cluster Type' fields need to be populated. The cluster name should match the name of the cluster that was built earlier in the workshop, and the URL will be provided by the workshop facilitators, but should look like this:
+1. There are only three **required** values to configure in this dialog: The 'Cluster Name', 'Central API Endpoint' (which must include a port number), and 'Cluster Type' fields need to be populated. The cluster name should match the name of the cluster that was built earlier in the workshop, and the Central API URL is the same as the one used to get into the ACS console, with the addition of the explicit port number at the end:
 
     ```
-    https://central-rhacs-operator.apps.poc-adobe-acs.tsir.p1.openshiftapps.com:443
+    https://central-rhacs-operator.apps.poc-adobe-acs.5fge.p1.openshiftapps.com:443
     ```
 
 The 'Cluster Type' should be set to 'OpenShift 4.x' for purposes of the workshop, though RHACS will also managed OCP 3.x and plain Kubernetes installs as well.


### PR DESCRIPTION
A couple of minor fixes:

- Added Incognito window guidance in install section
- Fixed wording in Cloud Shell instructions so it matches screenshot
- Fixed a typo in the Pod Disruption Budget section

Also fixed some missing content in the ACS section and updated the ACS section to refer to an actual ACS Central instance that's in-service in `eu-central-1`.